### PR TITLE
Fix Typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ production:
 ### Use for image url
 
 ```erb
-Orignial File URL:
+Original File URL:
 
 <%= image_tag @photo.image.service_url %>
 ```


### PR DESCRIPTION
Hi! I'm just trying your gem when I found a typo

Orignial > Original