### PR TITLE
improve put large object

### DIFF
--- a/lib/active_storage/service/aliyun_service.rb
+++ b/lib/active_storage/service/aliyun_service.rb
@@ -8,11 +8,13 @@ module ActiveStorage
       @config = config
     end
 
+    CHUNK_SIZE = 1024 * 1024
+
     def upload(key, io, checksum: nil, content_type: nil, disposition: nil, filename: nil)
       instrument :upload, key: key, checksum: checksum do
         content_type ||= Marcel::MimeType.for(io)
         bucket.put_object(path_for(key), content_type: content_type) do |stream|
-          stream << io.read
+          stream << io.read(CHUNK_SIZE) until io.eof?
         end
       end
     end


### PR DESCRIPTION
this improves the speed when uploading large object.
for example, a 50 MB file put from aliyun ecs:
![100x](https://user-images.githubusercontent.com/486841/56344796-e4316b00-61f0-11e9-8682-4b4f404b0c35.png)
